### PR TITLE
use crazy-max/cloudflared instead of official image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - ./data:/app
 
   paper-tunnel:
-    image: cloudflare/cloudflared:2021.12.2
+    image: crazymax/cloudflared:2021.11.0
     restart: always
     volumes:
       - ./cloudflared:/etc/cloudflared


### PR DESCRIPTION
- 公式のcloudflaredイメージではなく，`crazy-max/cloudflared`に差し替える
- 理由: 公式はamd64しかない
- これはこれでバージョン更新が遅かったりして微妙なので後で自作する